### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/draft_release.yaml
+++ b/.github/workflows/draft_release.yaml
@@ -93,7 +93,7 @@ jobs:
           mv build/compose/binaries/main/msi/omsi-launcher-*.msi omsi-launcher.msi
           & 'C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe' sign /fd certHash /f certificate\certificate.pfx /p '${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}' /t http://timestamp.sectigo.com/ /d omsi-launcher omsi-launcher.msi
       - name: Upload artifact
-        uses: actions/upload-artifact@v3.0.0
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: windows_distribution
           path: omsi-launcher.msi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     implementation("org.lwjgl", "lwjgl-nfd", "3.3.1", classifier = "natives-windows")
     implementation("br.com.devsrsouza.compose.icons.jetbrains", "tabler-icons", "1.0.0")
 
-    implementation("cafe.adriel.lyricist", "lyricist", "1.2.1")
+    implementation("cafe.adriel.lyricist", "lyricist", "1.2.2")
 
     ksp("cafe.adriel.lyricist", "lyricist-processor", "1.2.1")
     implementation(platform("dev.schlaubi:stdx-bom:1.1.0"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 
     implementation("cafe.adriel.lyricist", "lyricist", "1.2.2")
 
-    ksp("cafe.adriel.lyricist", "lyricist-processor", "1.2.1")
+    ksp("cafe.adriel.lyricist", "lyricist-processor", "1.2.2")
     implementation(platform("dev.schlaubi:stdx-bom:1.1.0"))
     implementation("dev.schlaubi", "stdx-serialization")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", "1.3.3")
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8", "1.6.1")
     implementation("org.jetbrains.kotlinx", "kotlinx-cli", "0.3.4")
-    implementation("io.github.microutils", "kotlin-logging", "2.1.21")
+    implementation("io.github.microutils", "kotlin-logging", "2.1.23")
     runtimeOnly("ch.qos.logback", "logback-classic", "1.2.11")
     implementation("net.java.dev.jna", "jna-platform", "5.11.0")
     implementation("org.lwjgl", "lwjgl", "3.3.1")


### PR DESCRIPTION
- Update dependency cafe.adriel.lyricist:lyricist to v1.2.2
- Update dependency cafe.adriel.lyricist:lyricist-processor to v1.2.2
- Update dependency io.github.microutils:kotlin-logging to v2.1.23
- Update actions/upload-artifact action to v3.1.0
