### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     kotlin("plugin.serialization") version "1.7.10"
     id("org.jetbrains.compose") version "1.2.0-alpha01-dev770"
     id("com.github.gmazzo.buildconfig") version "3.1.0"
-    id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
+    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
     id("com.google.devtools.ksp") version "1.7.10-1.0.6"
     id("org.jetbrains.changelog") version "1.3.1"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") version "1.2.0-alpha01-dev770"
     id("com.github.gmazzo.buildconfig") version "3.1.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
-    id("com.google.devtools.ksp") version "1.7.0-1.0.6"
+    id("com.google.devtools.ksp") version "1.7.10-1.0.6"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.7.10"
-    kotlin("plugin.serialization") version "1.7.0"
+    kotlin("plugin.serialization") version "1.7.10"
     id("org.jetbrains.compose") version "1.2.0-alpha01-dev770"
     id("com.github.gmazzo.buildconfig") version "3.1.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8", "1.6.4")
     implementation("org.jetbrains.kotlinx", "kotlinx-cli", "0.3.5")
     implementation("io.github.microutils", "kotlin-logging", "2.1.23")
-    runtimeOnly("ch.qos.logback", "logback-classic", "1.2.11")
+    runtimeOnly("ch.qos.logback", "logback-classic", "1.4.0")
     implementation("net.java.dev.jna", "jna-platform", "5.12.1")
     implementation("org.lwjgl", "lwjgl", "3.3.1")
     implementation("org.lwjgl", "lwjgl", "3.3.1", classifier = "natives-windows")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.7.0"
+    kotlin("jvm") version "1.7.10"
     kotlin("plugin.serialization") version "1.7.0"
     id("org.jetbrains.compose") version "1.2.0-alpha01-dev770"
     id("com.github.gmazzo.buildconfig") version "3.1.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") version "1.7.0"
     kotlin("plugin.serialization") version "1.7.0"
-    id("org.jetbrains.compose") version "1.2.0-alpha01-dev755"
+    id("org.jetbrains.compose") version "1.2.0-alpha01-dev770"
     id("com.github.gmazzo.buildconfig") version "3.1.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
     id("com.google.devtools.ksp") version "1.7.0-1.0.6"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     implementation(compose.desktop.currentOs)
-    implementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", "1.3.3")
+    implementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", "1.4.0")
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8", "1.6.4")
     implementation("org.jetbrains.kotlinx", "kotlinx-cli", "0.3.5")
     implementation("io.github.microutils", "kotlin-logging", "2.1.23")


### PR DESCRIPTION
- Update plugin com.google.devtools.ksp to v1.7.10-1.0.6
- Update plugin org.jetbrains.kotlin.jvm to v1.7.10
- Update plugin org.jetbrains.kotlin.plugin.serialization to v1.7.10
- Update dependency org.jetbrains.kotlinx:kotlinx-serialization-json to v1.4.0
- Update plugin org.jetbrains.compose to v1.2.0-alpha01-dev770
- Update plugin org.jlleitschuh.gradle.ktlint to v11
- Update dependency ch.qos.logback:logback-classic to v1.4.0
